### PR TITLE
Update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In most of the below cases, there will be a web interface running at http://loca
 Running with a warrior
 -------------------------
 
-Follow the [instructions on the ArchiveTeam wiki](http://archiveteam.org/index.php?title=Warrior) for installing the Warrior, and select the "Google+" project in the Warrior interface.
+Follow the [instructions on the ArchiveTeam wiki](http://archiveteam.org/index.php?title=ArchiveTeam_Warrior) for installing the Warrior, and select the "Google+" project in the Warrior interface.
 
 Running without a warrior
 -------------------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 googleplus-grab
 =============
 
-More information about the archiving project can be found on the ArchiveTeam wiki: [Google+](http://archiveteam.org/index.php?title=Google%2B)
+More information about the archiving project can be found on the ArchiveTeam wiki: [Google+](https://archiveteam.org/index.php?title=Google%2B)
 
 Setup instructions
 =========================
@@ -15,7 +15,7 @@ In most of the below cases, there will be a web interface running at http://loca
 Running with a warrior
 -------------------------
 
-Follow the [instructions on the ArchiveTeam wiki](http://archiveteam.org/index.php?title=ArchiveTeam_Warrior) for installing the Warrior, and select the "Google+" project in the Warrior interface.
+Follow the [instructions on the ArchiveTeam wiki](https://archiveteam.org/index.php?title=ArchiveTeam_Warrior) for installing the Warrior, and select the "Google+" project in the Warrior interface.
 
 Running without a warrior
 -------------------------
@@ -163,7 +163,7 @@ Install `seesaw` using `pip2` instead of `pip`.
 
 If you notice a bug and want to file a bug report, please use the GitHub issues tracker.
 
-Are you a developer? Help write code for us! Look at our [developer documentation](http://archiveteam.org/index.php?title=Dev) for details.
+Are you a developer? Help write code for us! Look at our [developer documentation](https://archiveteam.org/index.php?title=Dev) for details.
 
 ### Other problems
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 googleplus-grab
 =============
 
-More information about the archiving project can be found on the ArchiveTeam wiki: [Google+](http://archiveteam.org/index.php?title=Google+)
+More information about the archiving project can be found on the ArchiveTeam wiki: [Google+](http://archiveteam.org/index.php?title=Google%2B)
 
 Setup instructions
 =========================


### PR DESCRIPTION
- Properly escape plus sign (+):
  - http://archiveteam.org/index.php?title=Google+ -> 
    http://archiveteam.org/index.php?title=Google%2B
    former points to https://archiveteam.org/index.php?title=Google
- Remove unnecessary redirect:
  - http://archiveteam.org/index.php?title=Warrior -> 
    http://archiveteam.org/index.php?title=ArchiveTeam_Warrior
    former redirects to latter
- Use HTTPS:
  - http://archiveteam.org/index.php?title=Google%2B -> 
    https://archiveteam.org/index.php?title=Google%2B
  - http://archiveteam.org/index.php?title=ArchiveTeam_Warrior -> 
    https://archiveteam.org/index.php?title=ArchiveTeam_Warrior
  - http://archiveteam.org/index.php?title=Dev ->
    https://archiveteam.org/index.php?title=Dev